### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   deploy:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Potential fix for [https://github.com/hackinbrasil/hackinbrasil.github.io/security/code-scanning/1](https://github.com/hackinbrasil/hackinbrasil.github.io/security/code-scanning/1)

In general, the problem is fixed by adding an explicit `permissions:` block that restricts the `GITHUB_TOKEN` to the least privileges required. For a typical deploy job that only needs to read the repository contents and does not push commits, create releases, or modify issues/PRs, `contents: read` is usually sufficient. Additional scopes (like `packages: read`) should only be added if the job clearly needs them.

For this specific workflow in `.github/workflows/deploy-worker.yml`, the safest, non-breaking change is to add a `permissions:` block to the `deploy` job, since there is only one job and we have no evidence that it needs write access. The job performs: a checkout, Node setup, `npm install`, and `wrangler deploy` using Cloudflare secrets. None of these operations require write permissions to the GitHub repo via `GITHUB_TOKEN`. Therefore, you should insert:

```yaml
permissions:
  contents: read
```

under the `deploy:` job (same indentation level as `runs-on:`). No new imports or dependencies are needed; this is a pure YAML configuration change. Concretely, modify `.github/workflows/deploy-worker.yml` so that lines after `deploy:` include the `permissions:` block before or after `runs-on:` (order doesn’t matter, but we’ll place it right after `deploy:` to be clear).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
