### PR TITLE
Adiciona palestra de Felipe Pr0teus ao meetup 25/03/2026

### DIFF
--- a/meetup-25-03-2026.html
+++ b/meetup-25-03-2026.html
@@ -86,14 +86,19 @@ permalink: /meetup-25-03-2026/
         <p class="talk-time">20:45</p>
         <div class="talk-layout">
           <div class="talk-content">
-            <h3></h3>
-            <p></p>
+            <h3>Old dogs old tricks!</h3>
+            <p>
+              Atacantes continuam previsíveis. Nesta palestra, Felipe Pr0teus apresenta técnicas de decepção defensiva
+              em nível de rede que exploram padrões recorrentes de reconhecimento, enumeração e movimento lateral,
+              substituindo a negação pura por respostas falsas, porém plausíveis, capazes de distorcer fingerprinting,
+              quebrar automação e aumentar o custo operacional do ataque, gerando telemetria de alto sinal a partir de
+              comportamento real, usando ferramentas open-source, em cenários on-prem e cloud.
+            </p>
           </div>
           <aside class="talk-speaker">
-            <img src="{{ '/assets/images/hackinbrasil.png' | relative_url }}" alt="Foto de Palestrante 3">
-            <h4></h4>
-            <p class="speaker-role"></p>
-            <p></p>
+            <img src="{{ '/assets/images/hackinbrasil.png' | relative_url }}" alt="Foto de Felipe Pr0teus">
+            <h4>Felipe Pr0teus</h4>
+            <p class="speaker-role">Security Researcher na Tenchi Security</p>
           </aside>
         </div>
       </article>


### PR DESCRIPTION
### Motivation

- Incluir o último palestrante na programação do meetup para que o site reflita a agenda completa. 
- Fornecer título, descrição e metadados do palestrante para melhorar a informação acessível aos participantes.

### Description

- Atualiza o card das 20:45 no arquivo `meetup-25-03-2026.html` adicionando o título `Old dogs old tricks!` e a descrição completa da palestra. 
- Preenche os dados do palestrante no mesmo card definindo o `alt` da imagem, o nome `Felipe Pr0teus` e o cargo `Security Researcher na Tenchi Security`.

### Testing

- Serviu a página localmente com `python3 -m http.server 4173` e o servidor iniciou com sucesso. 
- Executou um script Playwright que abriu `http://127.0.0.1:4173/meetup-25-03-2026.html` e gerou a captura `artifacts/meetup-25-03-2026-felipe.png`, confirmando a renderização do card alterado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad6da21ac8832baaefabd14a2693bd)