### PR TITLE
Atualiza imagem do palestrante Felipe Pr0teus no meetup 25/03/2026

### DIFF
--- a/meetup-25-03-2026.html
+++ b/meetup-25-03-2026.html
@@ -96,7 +96,7 @@ permalink: /meetup-25-03-2026/
             </p>
           </div>
           <aside class="talk-speaker">
-            <img src="{{ '/assets/images/hackinbrasil.png' | relative_url }}" alt="Foto de Felipe Pr0teus">
+            <img src="{{ '/assets/images/speakers/proteus.jpeg' | relative_url }}" alt="Foto de Felipe Pr0teus">
             <h4>Felipe Pr0teus</h4>
             <p class="speaker-role">Security Researcher na Tenchi Security</p>
           </aside>


### PR DESCRIPTION
### Motivation
- Replace the generic project logo used on the speaker card with the actual photo uploaded for the speaker so the meetup page displays the correct portrait.

### Description
- Update the `<img>` `src` in `meetup-25-03-2026.html` to `'/assets/images/speakers/proteus.jpeg'` for Felipe Pr0teus' speaker card (replacing the previous `'/assets/images/hackinbrasil.png'`).

### Testing
- Ran `rg -n "proteus.jpeg|Felipe Pr0teus" meetup-25-03-2026.html`, started a local preview with `python3 -m http.server 8000`, and captured a visual verification screenshot via Playwright, and all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b849d5d56c832bb9b16683fae83ec9)