### PR TITLE
Update Mariana talk details

### DIFF
--- a/meetup-25-03-2026.html
+++ b/meetup-25-03-2026.html
@@ -64,14 +64,23 @@ permalink: /meetup-25-03-2026/
         <p class="talk-time">19:50</p>
         <div class="talk-layout">
           <div class="talk-content">
-            <h3></h3>
-            <p></p>
+            <h3>O papel da linguística na era dos Modelos de Linguagem: desafios e possibilidades</h3>
+            <p>
+              Com o surgimento dos modelos de linguagem em larga escala, o campo de Processamento de Linguagem Natural
+              (PLN) tem experimentado uma nova fase de interesse e expansão. Embora seja uma área interdisciplinar que
+              integra conhecimentos da linguística, da ciência da computação e da inteligência artificial, a participação
+              de linguistas ainda tende a se concentrar nas etapas de coleta e anotação de dados. Nesta apresentação,
+              discutiremos as principais transformações do PLN até o cenário atual, enquanto exploramos possíveis
+              contribuições da linguística para o avanço da área. A partir de exemplos, discutiremos a complexidade
+              inerente ao processamento computacional da língua e refletir sobre o potencial de um diálogo mais ativo
+              entre essas disciplinas. O objetivo da palestra é provocar questionamentos e despertar a curiosidade acerca
+              das interfaces entre linguagem humana e modelos computacionais.
+            </p>
           </div>
           <aside class="talk-speaker">
             <img src="{{ '/assets/images/speakers/mariana.jpeg' | relative_url }}" alt="Foto de Mariana Gonçalves">
             <h4>Mariana Gonçalves</h4>
             <p class="speaker-role">Mestranda na UFRJ</p>
-            <p></p>
           </aside>
         </div>
       </article>


### PR DESCRIPTION
### Motivation
- Update the Mariana Gonçalves talk on the March 25, 2026 meetup page with the provided title and full abstract to reflect the finalized talk information.
- Remove an empty speaker description paragraph to keep the speaker card consistent and avoid rendering an empty element.
- Keep the change scoped to the event page so other pages and assets remain unaffected.

### Description
- Replaced the empty talk content block in `meetup-25-03-2026.html` with the new title `O papel da linguística na era dos Modelos de Linguagem: desafios e possibilidades` and the full abstract provided.
- Removed the empty `<p></p>` line from Mariana's speaker card in `meetup-25-03-2026.html` so the speaker section contains only populated fields.
- No other files were modified and the change is content-only HTML update.

### Testing
- Ran `git diff -- meetup-25-03-2026.html` to verify the intended changes were present and the diff matched expectations (success).
- Inspected the updated lines with `nl -ba meetup-25-03-2026.html | sed -n '60,95p'` to confirm the title and abstract were inserted (success).
- Performed `git status --short && git add meetup-25-03-2026.html && git commit -m "Update Mariana talk details"` and `git rev-parse --abbrev-ref HEAD` to record the change in the repository, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc2b74aa9c832bae60d3c62c2da773)