### PR TITLE
Atualiza descrição da talk de Diego Afonso no meetup 25/04/2026

### DIFF
--- a/meetup-25-04-2026.html
+++ b/meetup-25-04-2026.html
@@ -48,12 +48,12 @@ permalink: /meetup-25-04-2026/
         <p class="talk-time">10:50</p>
         <div class="talk-layout">
           <div class="talk-content">
-            <h3>Cibersegurança, HOJE você aprende • Diego Affonso</h3>
-            <p>Senior Cybersecurity Analyst.</p>
+            <h3>Cibersegurança, HOJE você aprende • Diego Afonso</h3>
+            <p>Uma talk sobre como atacantes reais operam e o que muda quando você começa a pensar como eles.</p>
           </div>
           <aside class="talk-speaker">
-            <img src="{{ '/assets/images/speakers/diego-affonso.jpg' | relative_url }}" alt="Foto de Diego Affonso">
-            <h4>Diego Affonso</h4>
+            <img src="{{ '/assets/images/speakers/diego-affonso.jpg' | relative_url }}" alt="Foto de Diego Afonso">
+            <h4>Diego Afonso</h4>
             <p>Senior Cybersecurity Analyst.</p>
           </aside>
         </div>


### PR DESCRIPTION
### Motivation
- Corrigir o nome do palestrante e atualizar a descrição da talk exibida no site para refletir o texto fornecido.

### Description
- Atualiza o arquivo `meetup-25-04-2026.html` substituindo "Diego Affonso" por "Diego Afonso", alterando a descrição da palestra para: "Uma talk sobre como atacantes reais operam e o que muda quando você começa a pensar como eles.", e ajustando o `alt` da imagem e o nome exibido no card do palestrante.

### Testing
- Não há testes automatizados aplicáveis a esta alteração de conteúdo estático (HTML).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd8444ed0c832bb766cd557828f86f)