### PR TITLE
Atualiza primeira palestra com título/descrição e dois palestrantes

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -910,6 +910,23 @@ footer a {
   font-size: 0.88rem;
 }
 
+.talk-speaker-list {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  height: 100%;
+}
+
+.talk-speaker-person {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.talk-speaker-person h4 {
+  margin-bottom: 0;
+}
+
 .talk-content h3:empty,
 .talk-content p:empty,
 .talk-speaker h4:empty,
@@ -1492,6 +1509,10 @@ footer a {
   }
 
   .talk-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .talk-speaker-list {
     grid-template-columns: 1fr;
   }
 

--- a/meetup-25-04-2026.html
+++ b/meetup-25-04-2026.html
@@ -34,12 +34,32 @@ permalink: /meetup-25-04-2026/
         <p class="talk-time">10:00</p>
         <div class="talk-layout">
           <div class="talk-content">
-            <h3>Palestra 1 • Daniel Meirelles</h3>
-            <p>Palestrante confirmado para a abertura do meetup.</p>
+            <h3>
+              Enquanto o mundo debate a educação digital infantil, como
+              você como prepara os seus filhos?
+            </h3>
+            <p>
+              Esta palestra convida pais e educadores a refletirem sobre
+              seu papel na formação de crianças conscientes e responsáveis
+              no ambiente online. Mais do que alertar sobre riscos,
+              apresenta caminhos práticos para educar com equilíbrio,
+              fortalecer o diálogo familiar e preparar os filhos para o
+              uso saudável da tecnologia. Além disso, apresenta o projeto
+              O Cibernauta como um importante aliado na educação digital
+              infantil.
+            </p>
           </div>
           <aside class="talk-speaker">
-            <img src="{{ '/assets/images/speakers/meirelles.jpg' | relative_url }}" alt="Foto de Daniel Meirelles">
-            <h4>Daniel Meirelles</h4>
+            <div class="talk-speaker-list">
+              <div class="talk-speaker-person">
+                <img src="{{ '/assets/images/speakers/meirelles.jpg' | relative_url }}" alt="Foto de Daniel Meirelles">
+                <h4>Daniel Meirelles</h4>
+              </div>
+              <div class="talk-speaker-person">
+                <img src="{{ '/assets/images/speakers/argollo.jpg' | relative_url }}" alt="Foto de Eduardo Argollo">
+                <h4>Eduardo Argollo</h4>
+              </div>
+            </div>
           </aside>
         </div>
       </article>


### PR DESCRIPTION
### Motivation
- Replace the placeholder first talk with the requested title and full description about educating children for healthy digital use.
- Display both Daniel Meirelles and Eduardo Argollo simultaneously in the first talk slot with name and photo for each.
- Ensure the speakers slot works responsively by adding layout support for multiple speakers.

### Description
- Update `meetup-25-04-2026.html` to set the new `h3` title and detailed `p` description for the 10:00 talk and replace the single-speaker markup with a `talk-speaker-list` containing two `talk-speaker-person` entries for Daniel and Eduardo.
- Add CSS rules in `assets/css/style.css` for `.talk-speaker-list` and `.talk-speaker-person` to present two columns on desktop and collapse to one column on mobile via the existing responsive media block.
- Commit changes to the repository so the new layout and content are included in the site source.

### Testing
- Attempted a site build with `bundle exec jekyll build`, which failed because the `jekyll` executable is not available in the environment.
- Verified repository changes were committed successfully using `git status --short` and the local commit recorded the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de393673fc832b829dadcbf44230d6)