### PR TITLE
Atualiza agenda do meetup de 25/04/2026: adiciona Abertura e ajusta horários

### DIFF
--- a/meetup-25-04-2026.html
+++ b/meetup-25-04-2026.html
@@ -32,6 +32,12 @@ permalink: /meetup-25-04-2026/
     <div class="talks-grid">
       <article class="talk-card">
         <p class="talk-time">10:00</p>
+        <h3>Abertura</h3>
+        <p>Anúncios da organização, recados iniciais e visão geral da agenda do meetup.</p>
+      </article>
+
+      <article class="talk-card">
+        <p class="talk-time">10:15</p>
         <div class="talk-layout">
           <div class="talk-content">
             <h3>
@@ -89,20 +95,19 @@ permalink: /meetup-25-04-2026/
         <p class="talk-time">12:00</p>
         <div class="talk-layout">
           <div class="talk-content">
-            <h3>Palestra 3 • Eduardo Argollo</h3>
-            <p>Palestrante confirmado para o encerramento técnico do meetup.</p>
+            <h3>Palestra 3 • A definir</h3>
+            <p>Última palestra em definição. Em breve divulgaremos os detalhes.</p>
           </div>
           <aside class="talk-speaker">
-            <img src="{{ '/assets/images/speakers/argollo.jpg' | relative_url }}" alt="Foto de Eduardo Argollo">
-            <h4>Eduardo Argollo</h4>
+            <h4>Palestrante a definir</h4>
           </aside>
         </div>
       </article>
 
       <article class="talk-card">
         <p class="talk-time">12:50</p>
-        <h3>Encerramento</h3>
-        <p>Agradecimentos finais e fechamento das atividades às 13h.</p>
+        <h3>Encerramento & sorteios</h3>
+        <p>Agradecimentos finais, sorteios e fechamento das atividades às 13h.</p>
       </article>
     </div>
   </section>


### PR DESCRIPTION
### Motivation
- Atualizar a página do meetup para refletir a sequência real de atividades definida pela organização.
- Incluir um slot de abertura antes da primeira palestra e ajustar os horários para corresponder ao cronograma informado.
- Remover a atribuição de Eduardo como responsável pela última palestra enquanto o conteúdo final estiver em definição. 

### Description
- Inserido um novo artigo `Abertura` às `10:00` com texto de anúncios e recados iniciais no arquivo `meetup-25-04-2026.html`.
- Ajustado o bloco da palestra conjunta de Daniel Meirelles e Eduardo Argollo para iniciar às `10:15` movendo seu conteúdo sob o horário atualizado. 
- Substituída a entrada da última palestra por `Palestra 3 • A definir` e removida a foto/nome de Eduardo Argollo do bloco correspondente. 
- Alterado o bloco final para `Encerramento & sorteios` com descrição atualizada e commit aplicado ao repositório.

### Testing
- Executado `git diff --check` sem erros (passou).
- Verificado o status com `git status --short` para confirmar o arquivo modificado (listagem presente).
- Realizado `git commit` da alteração com mensagem descritiva e commit concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de7df0f118832bb0db1b2a06c8a808)