### PR TITLE
Fix typo in first talk title for April 25 meetup

### DIFF
--- a/meetup-25-04-2026.html
+++ b/meetup-25-04-2026.html
@@ -42,7 +42,7 @@ permalink: /meetup-25-04-2026/
           <div class="talk-content">
             <h3>
               Enquanto o mundo debate a educação digital infantil, como
-              você como prepara os seus filhos?
+              você prepara os seus filhos?
             </h3>
             <p>
               Esta palestra convida pais e educadores a refletirem sobre


### PR DESCRIPTION
### Motivation
- Correct a duplicated word in the first talk title so the heading reads naturally: "você prepara os seus filhos?".

### Description
- Updated `meetup-25-04-2026.html` replacing "você como prepara os seus filhos?" with "você prepara os seus filhos?" in the first talk's `<h3>`.

### Testing
- No automated tests were run for this content-only HTML text fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e004a61224832b9801d0503944f706)